### PR TITLE
Feat/8-dev-container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "Python 3",
+	"name": "Kepler16b Using IMCE Vocabulary",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
 	"features": {
@@ -14,11 +14,7 @@
 			"antVersion": "1.10.12",
 			"groovyVersion": "latest"
 		},
-		"ghcr.io/rocker-org/devcontainer-features/r-apt:0": {
-			"installRMarkdown": true,
-			"useTesting": true,
-			"vscodeRSupport": "minimal"
-		}
+		"ghcr.io/rocker-org/devcontainer-features/r-rig:1": {}
 	}
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"installGradle": true,
+			"version": "17",
+			"jdkDistro": "ms",
+			"gradleVersion": "7.5.1",
+			"mavenVersion": "3.8.6",
+			"antVersion": "1.10.12",
+			"groovyVersion": "latest"
+		},
+		"ghcr.io/rocker-org/devcontainer-features/r-apt:0": {
+			"installRMarkdown": true,
+			"useTesting": true,
+			"vscodeRSupport": "minimal"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
closes #8 

How to Test:
1. Open `feat/8-dev-container` branch in a codespace
2. Run `java -version` and verify you are on Java 17
3. Run `python -version` and verify you are on Python 3.12
4. Run `R -version` and verify you are on R 4.4.0
5. Run `./gradlew load`
6. Go to Ports and click `Forward a Port`
7. Enter in `3000`
<img width="1840" alt="image" src="https://github.com/UTNAK/kepler16b-using-imce-vocabulary/assets/108915844/fb7ced37-d213-41fd-bd74-2231ca79b52b">
8. Go to the web link that is shown after entering in `3000`
9. Verify that the Fuseki web server opens after going to that link